### PR TITLE
fixed the bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev -p 3003",
+    "dev": "next dev -p 3000",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
(Closed the previous PR because my silly self forgot to change the base and it was main)

Found a bug when running localhost where auth0 callbacks would return a 404 error.

![image](https://user-images.githubusercontent.com/92929470/156876168-2deed30d-1500-49c9-9ada-c9c23891ef24.png)

The fix was simple, the port in package.json was changed from 3000 to 3003, now it's back to 3000.
Auth0 was unable to find localhost:3003 as it's not part of the allowed redirect/callback urls.